### PR TITLE
Helper to check reported messages in Zinc scripted tests

### DIFF
--- a/zinc/src/sbt-test/reporter/errors-reported/A.scala
+++ b/zinc/src/sbt-test/reporter/errors-reported/A.scala
@@ -1,0 +1,3 @@
+class A {
+  val x: String = 0
+}

--- a/zinc/src/sbt-test/reporter/errors-reported/pending
+++ b/zinc/src/sbt-test/reporter/errors-reported/pending
@@ -1,0 +1,3 @@
+-> compile
+
+> checkErrors 1

--- a/zinc/src/sbt-test/reporter/warnings-reported/A.scala
+++ b/zinc/src/sbt-test/reporter/warnings-reported/A.scala
@@ -1,0 +1,4 @@
+class A {
+  val x: List[Int] = Nil
+  x.isInstanceOf[List[String]]
+}

--- a/zinc/src/sbt-test/reporter/warnings-reported/test
+++ b/zinc/src/sbt-test/reporter/warnings-reported/test
@@ -1,0 +1,4 @@
+> compile
+$ pause
+> checkWarnings 1
+> checkWarning 0 "fruitless type test"


### PR DESCRIPTION
This commit introduces support for 4 new commands in Zinc scripted tests:
- `checkWarnings x`: checks that the incremental compiler has registered
  x warnings.
  Example: `checkWarnings 4`
- `checkWarning i msg`: checks that the i-th warning's message contains
  `msg`.
  Example: `checkWarning 2 deprecation`
- `checkErrors x`: checks that the incremental compiler has registered
  x errors.
- `checkError i msg`: checks that the i-th error's message contains
  `msg`.

At the moment, zinc cannot register error messages because nothing is
registered when the compilation fails.
