### PR TITLE
Fix issue with 2.10 traversals

### DIFF
--- a/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/internal/compiler-bridge/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -180,7 +180,10 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
           original.foreach(traverse)
         }
       case t if t.hasSymbolField =>
-        addSymbol(getNamesOfEnclosingScope, t.symbol)
+        val symbol = t.symbol
+        if (symbol != rootMirror.RootPackage)
+          addSymbol(getNamesOfEnclosingScope, t.symbol)
+
         val tpe = t.tpe
         if (!ignoredType(tpe)) {
           // Initialize _currentOwner if it's not


### PR DESCRIPTION
This issue was fixed in https://github.com/sbt/zinc/pull/239/files#diff-65c95a9d18dc8a76c6182e1c6377fc65R154.

For some reason, 2.10 compiler is detecting root packages to have
symbols fields (which 2.11 do not recognise as such), so we need to
protect from them in `ExtractUsedNames` since `_root_` should definitely
not be registered as a name, because it's present in any Scala source
file.